### PR TITLE
Update HSBC cashback percentage on utility payments

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -142,7 +142,7 @@ const cards = [
       offlineSpends: 0.015,
       onlineSpends: 0.015,
       rent: 0.0,
-      utilities: 0.015,
+      utilities: 0.0,
       walletLoads: 0.0,
     }
   },


### PR DESCRIPTION
Updates the cashback percentage for HSBC Cashback Credit Card on utility payments to 0% in `src/App.js`.

- Changes the cashback rate for utilities under the HSBC Cashback Credit Card from 1.5% to 0% to align with the new cashback policy.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/cyberboysumanjay/CashbackCardComparisonTool?shareId=37d6750a-4839-49a9-af21-9ae7a71fe012).